### PR TITLE
prepare a old config for make menuconfig

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,12 @@ CMAKE=$SHELL_DIR/toolchain/cmake/bin/
 LINUX_CROSS_PREFIX=$SHELL_DIR/toolchain/linux_toolchain/bin/riscv64-unknown-linux-gnu-
 NEWLIB_ELF_CROSS_PREFIX=$SHELL_DIR/toolchain/elf_newlib_toolchain/bin/riscv64-unknown-elf-
 
-BUILD_TARGET=$1
+# if no arg given
+if [ $# -ne 1 ]; then
+	BUILD_TARGET="--help"
+else
+	BUILD_TARGET=$1
+fi
 
 if [[ ! -e $OUT_DIR ]]; then
     mkdir $OUT_DIR

--- a/build.sh
+++ b/build.sh
@@ -35,6 +35,12 @@ build_linux_config()
     echo " "
     echo "============ build linux kernel config ============="
     cd $SHELL_DIR/linux-5.10.4-808
+    # add old config for make menuconfig,
+    # otherwise it will take config from /boot/config-<kernel ver> of host,
+    # and kernel building will fail.
+    if [ ! -f .config ]; then
+        cp c906.config .config
+    fi
     make ARCH=riscv CROSS_COMPILE=$LINUX_CROSS_PREFIX menuconfig -j$(nproc)
 }
 


### PR DESCRIPTION
This pull request includes:
- add a old config for 'make menuconfig' when building kernel, otherwise it will use host kernel config as template to generate .config and cause kernel building failed.
- if no arg given to build.sh, show help
